### PR TITLE
Feat/offscreen teleport

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.1'
     testImplementation 'org.assertj:assertj-core:3.6.2'
+    testImplementation 'org.mockito:mockito-core:1.+'
 }
 
 processResources {

--- a/docs/mob/customai.md
+++ b/docs/mob/customai.md
@@ -4,10 +4,13 @@ Onslaught contains several custom AI tasks that can be assigned to entities usin
 
 All custom AI NBT needs to be placed inside the `ForgeData/Onslaught/CustomAI` tag.
 
-Each task exposes some optionally configurable properties. If you omit any of the properties, defaults from the mod's config file will be used: `config/onslaught/onslaught.cfg`.
+Each task exposes some optionally configurable properties. If you omit any of the properties,
+defaults from the mod's config file will be used: `config/onslaught/onslaught.cfg`.
 
 !!! warning "Task Priority"
-    Each task does expose a configurable priority, however, we recommended that you omit the `Priority` tag and let the mod use the defaults. The default priorities should work for most mobs and changing them may result in undesirable behavior and performance hits.
+Each task does expose a configurable priority, however, we recommended that you omit the `Priority`
+tag and let the mod use the defaults. The default priorities should work for most mobs and changing
+them may result in undesirable behavior and performance hits.
 
 ## AntiAir
 
@@ -20,7 +23,7 @@ Range         | int     | [1,-) | 128  | range within which a mob will pull the 
 SightRequired | boolean | N/A   | true | does the mob need to have sight of the player to pull them down
 MotionY       | double  | (-,0] | -0.4 | the Y axis force applied to the player
 
-```js
+```json
 {
   "zombie_antiair": {
     "id": "minecraft:zombie",
@@ -45,22 +48,24 @@ MotionY       | double  | (-,0] | -0.4 | the Y axis force applied to the player
 The mod's config file contains additional options to:
 
 * set the number of ticks that the player is allowed to be in the air, and
-* toggle summing the downward force of all affecting mobs or using only the single largest force. 
+* toggle summing the downward force of all affecting mobs or using only the single largest force.
 
 ## AttackMelee
 
 The `AttackMelee` task allows a passive mob to attack.
 
-!!! note
-    This task will only work with mobs that can be given an attack target. For example, attaching this task to a Pig will do nothing because the Pig does not naturally target entities to attack. This task will work with mobs spawned by the invasion system because they are given the ability to persistently target the invaded player.
-    
+!!! note This task will only work with mobs that can be given an attack target. For example,
+attaching this task to a Pig will do nothing because the Pig does not naturally target entities to
+attack. This task will work with mobs spawned by the invasion system because they are given the
+ability to persistently target the invaded player.
+
 key | type | range | default | description
 :---|:---|:---|:---|:---
 Priority      | int     | N/A   | -3 | task priority
 Speed         | double  | [0,-) | 1  | movement speed when attacking
 AttackDamage  | int     | [0,-) | 1  | attack damage in half-hearts
 
-```js
+```json
 {
   "pig_attackmelee": {
     "id": "minecraft:pig",
@@ -83,17 +88,20 @@ AttackDamage  | int     | [0,-) | 1  | attack damage in half-hearts
 
 ## ChaseLongDistance
 
-The `ChaseLongDistance` task operates in tandem with the TargetPlayer task to allow mobs to target the invaded player over a long distance. This task will do nothing without the TargetPlayer task because the mob will never have a long-distance target. 
+The `ChaseLongDistance` task operates in tandem with the TargetPlayer task to allow mobs to target
+the invaded player over a long distance. This task will do nothing without the TargetPlayer task
+because the mob will never have a long-distance target.
 
-!!! warning
-    This task is automatically applied to mobs spawned by an invasion and should not be manually applied unless you want to change the task's default properties. This task can be applied manually along with the `TargetPlayer` task for testing purposes.
-    
- key | type | range | default | description
+!!! warning This task is automatically applied to mobs spawned by an invasion and should not be
+manually applied unless you want to change the task's default properties. This task can be applied
+manually along with the `TargetPlayer` task for testing purposes.
+
+key | type | range | default | description
  :---|:---|:---|:---|:---
- Priority      | int     | N/A   | -10 | task priority
- Speed         | double  | [0,-) | 1   | movement speed when out of range
+Priority      | int     | N/A   | -10 | task priority
+Speed         | double  | [0,-) | 1   | movement speed when out of range
 
-```js
+```json
 {
   "zombie_chaselongdistance": {
     "id": "minecraft:zombie",
@@ -126,10 +134,12 @@ Chance        | double  | [0,1]   | 1    | the chance of counterattacking per ti
 RangeMin      | double  | [0,max) | 2    | minimum range required to counterattack
 RangeMax      | double  | (min,-) | 4    | maximum range required to counterattack
 
-!!! note
-    The `Chance` parameter will not prevent the task from executing, but it may delay or vary the timing of its execution. Think of it as more of a random delay than a chance to occur. Each tick after the mob is attacked, the logic rolls against the chance parameter to determine if the counter fires.
+!!! note The `Chance` parameter will not prevent the task from executing, but it may delay or vary
+the timing of its execution. Think of it as more of a random delay than a chance to occur. Each tick
+after the mob is attacked, the logic rolls against the chance parameter to determine if the counter
+fires.
 
-```js
+```json
 {
   "zombie_counterattack": {
     "id": "minecraft:zombie",
@@ -169,7 +179,7 @@ ExplosionStrength   | double  | [1,-)   | 3     | explosion strength
 ExplosionCausesFire | boolean | N/A     | false | does the explosion cause fires
 ExplosionDamaging   | boolean | N/A     | true  | does the explosion break blocks
 
-```js
+```json
 {
   "zombie_explodewhenstuck": {
     "id": "minecraft:zombie",
@@ -206,7 +216,7 @@ Priority      | int    | N/A   | -15 | task priority
 Range         | int    | [1,-) | 6   | the range within which a mob will increase its speed
 SpeedModifier | double | [0,-) | 0.3 | multiplicative speed modifier
 
-```js
+```json
 {
   "zombie_lunge": {
     "id": "minecraft:zombie",
@@ -237,7 +247,7 @@ Priority      | int    | N/A   | -9 | task priority
 Range         | int    | [1,-) | 4  | the range within which a mob will break blocks
 SpeedModifier | double | [0,-) | 1  | multiplicative mining speed modifier
 
-```js
+```json
 {
   "zombie_mining": {
     "id": "minecraft:zombie",
@@ -262,15 +272,17 @@ SpeedModifier | double | [0,-) | 1  | multiplicative mining speed modifier
 
 The `TargetPlayer` task will cause a mob to persistently target the given player by UUID.
 
-!!! warning
-    This task is automatically applied to mobs spawned by an invasion and should not be manually applied. This task can be applied manually along with the `ChaseLongDistance` task for testing purposes.
+!!! warning This task is automatically applied to mobs spawned by an invasion and should not be
+manually applied. This task can be applied manually along with the `ChaseLongDistance` task for
+testing purposes.
 
 key | type | range | default | description
 :---|:---|:---|:---|:---
 Priority | int    | N/A | 10  | task priority
 UUID     | string | N/A | N/A | the UUID of the player to persistently target
 
-```js
+```json
+{
   "zombie_targetplayer": {
     "id": "minecraft:zombie",
     "nbt": {
@@ -280,6 +292,48 @@ UUID     | string | N/A | N/A | the UUID of the player to persistently target
             "TargetPlayer": {
               "Priority": 10,
               "UUID": "46562dd7-ada9-4af8-b88c-3a0f2d3e8860"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Offscreen Teleport
+
+The `OffscreenTeleport` task allows the mob to teleport closer if the target gets too far. If
+triggered, the mob will briefly disappear and reappear, and emitting its ambient noise.
+
+The **TeleportFactor** will move the mob closer by that fraction of the distance from the target.
+Values less than one moves the mob a portion of the distance to the player. Values greater than one
+will put them on the other side of the player when teleporting. The different ranges produce the
+following:
+
+* `.5` a **Chaser**, always not far behind
+* `1.0` a **Jump Scare**, suddenly appearing if you try to flee
+* `1.5` a **Flanker**, cuts you off
+
+key | type | range | default | description
+:---|:---|:---|:---|:---
+TeleportDistance | int    | - | 64  | Distance in blocks to start teleporting
+TeleportFactor     | double | -| .5 | Factor to move closer
+DimensionHopping | boolean | -| true | Attempt to hop into the player's dimension if in another one
+
+```json
+{
+  "teleporter.flanker": {
+    "id": "minecraft:husk",
+    "nbt": {
+      "CustomName": "Flanking Husk",
+      "ForgeData": {
+        "Onslaught": {
+          "CustomAI": {
+            "OffscreenTeleport": {
+              "TeleportDistance": 32,
+              "TeleportFactor": 1.3,
+              "DimensionHopping": true
             }
           }
         }

--- a/docs/mob/customai.md
+++ b/docs/mob/customai.md
@@ -8,9 +8,9 @@ Each task exposes some optionally configurable properties. If you omit any of th
 defaults from the mod's config file will be used: `config/onslaught/onslaught.cfg`.
 
 !!! warning "Task Priority"
-Each task does expose a configurable priority, however, we recommended that you omit the `Priority`
-tag and let the mod use the defaults. The default priorities should work for most mobs and changing
-them may result in undesirable behavior and performance hits.
+    Each task does expose a configurable priority, however, we recommended that you omit the `Priority`
+    tag and let the mod use the defaults. The default priorities should work for most mobs and changing
+    them may result in undesirable behavior and performance hits.
 
 ## AntiAir
 
@@ -55,9 +55,9 @@ The mod's config file contains additional options to:
 The `AttackMelee` task allows a passive mob to attack.
 
 !!! note This task will only work with mobs that can be given an attack target. For example,
-attaching this task to a Pig will do nothing because the Pig does not naturally target entities to
-attack. This task will work with mobs spawned by the invasion system because they are given the
-ability to persistently target the invaded player.
+    attaching this task to a Pig will do nothing because the Pig does not naturally target entities to
+    attack. This task will work with mobs spawned by the invasion system because they are given the
+    ability to persistently target the invaded player.
 
 key | type | range | default | description
 :---|:---|:---|:---|:---
@@ -93,8 +93,8 @@ the invaded player over a long distance. This task will do nothing without the T
 because the mob will never have a long-distance target.
 
 !!! warning This task is automatically applied to mobs spawned by an invasion and should not be
-manually applied unless you want to change the task's default properties. This task can be applied
-manually along with the `TargetPlayer` task for testing purposes.
+    manually applied unless you want to change the task's default properties. This task can be applied
+    manually along with the `TargetPlayer` task for testing purposes.
 
 key | type | range | default | description
  :---|:---|:---|:---|:---
@@ -135,9 +135,9 @@ RangeMin      | double  | [0,max) | 2    | minimum range required to counteratta
 RangeMax      | double  | (min,-) | 4    | maximum range required to counterattack
 
 !!! note The `Chance` parameter will not prevent the task from executing, but it may delay or vary
-the timing of its execution. Think of it as more of a random delay than a chance to occur. Each tick
-after the mob is attacked, the logic rolls against the chance parameter to determine if the counter
-fires.
+    the timing of its execution. Think of it as more of a random delay than a chance to occur. Each tick
+    after the mob is attacked, the logic rolls against the chance parameter to determine if the counter
+    fires.
 
 ```json
 {
@@ -273,8 +273,8 @@ SpeedModifier | double | [0,-) | 1  | multiplicative mining speed modifier
 The `TargetPlayer` task will cause a mob to persistently target the given player by UUID.
 
 !!! warning This task is automatically applied to mobs spawned by an invasion and should not be
-manually applied. This task can be applied manually along with the `ChaseLongDistance` task for
-testing purposes.
+    manually applied. This task can be applied manually along with the `ChaseLongDistance` task for
+    testing purposes.
 
 key | type | range | default | description
 :---|:---|:---|:---|:---

--- a/src/main/java/com/codetaylor/mc/onslaught/modules/onslaught/ModuleOnslaught.java
+++ b/src/main/java/com/codetaylor/mc/onslaught/modules/onslaught/ModuleOnslaught.java
@@ -14,6 +14,7 @@ import com.codetaylor.mc.onslaught.modules.onslaught.command.CommandStopInvasion
 import com.codetaylor.mc.onslaught.modules.onslaught.command.CommandSummon;
 import com.codetaylor.mc.onslaught.modules.onslaught.entity.ai.EntityAIChaseLongDistance;
 import com.codetaylor.mc.onslaught.modules.onslaught.entity.ai.EntityAIChaseLongDistanceGhast;
+import com.codetaylor.mc.onslaught.modules.onslaught.entity.ai.EntityAIOffscreenTeleport;
 import com.codetaylor.mc.onslaught.modules.onslaught.entity.ai.EntityAIPlayerTarget;
 import com.codetaylor.mc.onslaught.modules.onslaught.entity.ai.injector.EntityAIAntiAirInjector;
 import com.codetaylor.mc.onslaught.modules.onslaught.entity.ai.injector.EntityAIAttackMeleeInjector;
@@ -214,7 +215,8 @@ public class ModuleOnslaught extends ModuleBase {
     Class<?>[] entityAIToRemoveOnCleanup = {
       EntityAIPlayerTarget.class,
       EntityAIChaseLongDistance.class,
-      EntityAIChaseLongDistanceGhast.class
+      EntityAIChaseLongDistanceGhast.class,
+      EntityAIOffscreenTeleport.class
     };
 
     // -------------------------------------------------------------------------

--- a/src/main/java/com/codetaylor/mc/onslaught/modules/onslaught/ModuleOnslaught.java
+++ b/src/main/java/com/codetaylor/mc/onslaught/modules/onslaught/ModuleOnslaught.java
@@ -23,6 +23,7 @@ import com.codetaylor.mc.onslaught.modules.onslaught.entity.ai.injector.EntityAI
 import com.codetaylor.mc.onslaught.modules.onslaught.entity.ai.injector.EntityAIInjectorBase;
 import com.codetaylor.mc.onslaught.modules.onslaught.entity.ai.injector.EntityAILungeInjector;
 import com.codetaylor.mc.onslaught.modules.onslaught.entity.ai.injector.EntityAIMiningInjector;
+import com.codetaylor.mc.onslaught.modules.onslaught.entity.ai.injector.EntityAIOffscreenTeleportInjector;
 import com.codetaylor.mc.onslaught.modules.onslaught.entity.ai.injector.EntityAIPlayerTargetInjector;
 import com.codetaylor.mc.onslaught.modules.onslaught.entity.factory.EffectApplicator;
 import com.codetaylor.mc.onslaught.modules.onslaught.entity.factory.LootTableApplicator;
@@ -205,7 +206,8 @@ public class ModuleOnslaught extends ModuleBase {
               new EntityAICounterAttackInjector(),
               new EntityAIExplodeWhenStuckInjector(),
               new EntityAILungeInjector(),
-              new EntityAIAntiAirInjector()
+              new EntityAIAntiAirInjector(),
+              new EntityAIOffscreenTeleportInjector()
             }));
 
     // The entity AI classes to strip from mobs during invasion cleanup

--- a/src/main/java/com/codetaylor/mc/onslaught/modules/onslaught/ModuleOnslaughtConfig.java
+++ b/src/main/java/com/codetaylor/mc/onslaught/modules/onslaught/ModuleOnslaughtConfig.java
@@ -3,7 +3,7 @@ package com.codetaylor.mc.onslaught.modules.onslaught;
 import com.codetaylor.mc.onslaught.modules.onslaught.template.invasion.InvasionTemplateWave;
 import net.minecraftforge.common.config.Config;
 
-@Config(modid = ModuleOnslaught.MOD_ID, name = ModuleOnslaught.MOD_ID + "/" + "onslaught")
+@Config(modid = ModuleOnslaught.MOD_ID)
 public class ModuleOnslaughtConfig {
 
   public static Debug DEBUG = new Debug();
@@ -203,6 +203,8 @@ public class ModuleOnslaughtConfig {
     public AttackMelee ATTACK_MELEE = new AttackMelee();
     public LongDistanceChase LONG_DISTANCE_CHASE = new LongDistanceChase();
     public Mining MINING = new Mining();
+    @Config.Name("Offscreen Teleport")
+    public OffscreenTeleport OFFSCREEN_TELEPORT = new OffscreenTeleport();
 
     public static class AntiAir {
 
@@ -410,6 +412,34 @@ public class ModuleOnslaughtConfig {
       })
       @Config.RangeDouble(min = 0)
       public double DEFAULT_SPEED_MODIFIER = 1;
+    }
+
+    public static class OffscreenTeleport {
+      @Config.Comment({
+        "The default offscreen teleport range for mobs to trigger a relocate.",
+        "Can be overridden in a mob template or with NBT.",
+        "Default: " + 64
+      })
+      @Config.RangeInt(min = 1)
+      public int DEFAULT_RANGE = 64;
+
+      @Config.Comment({
+        "The default teleportation factor to 'move closer' to the target.",
+        "0.5 => move half the distance",
+        "1.0 => move directly on top of target",
+        "1.5 => move to the target, then half again to flank the target.",
+        "Can be overridden in a mob template or with NBT.",
+        "Default: " + 1.5
+      })
+      @Config.RangeDouble(min = 0, max = 2)
+      public double DEFAULT_FACTOR = 1.5;
+
+      @Config.Comment({
+        "The default ability to teleport across dimensions to chase the target",
+        "Can be overridden in a mob template or with NBT.",
+        "Default: " + true
+      })
+      public boolean DEFAULT_DIM_HOPPING = true;
     }
   }
 }

--- a/src/main/java/com/codetaylor/mc/onslaught/modules/onslaught/Tag.java
+++ b/src/main/java/com/codetaylor/mc/onslaught/modules/onslaught/Tag.java
@@ -38,6 +38,9 @@ public final class Tag {
   public static final String AI_PARAM_SPEED = "Speed";
   public static final String AI_PARAM_SPEED_MODIFIER = "SpeedModifier";
   public static final String AI_PARAM_UUID = "UUID";
+  public static final String AI_PARAM_TELE_THRESHOLD = "TeleportDistance";
+  public static final String AI_PARAM_TELE_FACTOR = "TeleportFactor";
+  public static final String AI_PARAM_DIM_HOP = "DimensionHopping";
 
   public static final String INVASION_DATA = "InvasionData";
   public static final String INVASION_PLAYER_UUID = "PlayerUUID";

--- a/src/main/java/com/codetaylor/mc/onslaught/modules/onslaught/Tag.java
+++ b/src/main/java/com/codetaylor/mc/onslaught/modules/onslaught/Tag.java
@@ -10,6 +10,7 @@ public final class Tag {
   public static final String EXTRA_LOOT_TABLES = "ExtraLootTables";
   public static final String ONSLAUGHT = "Onslaught";
 
+  public static final String AI_OFFSCREEN_TELEPORT = "OffscreenTeleport";
   public static final String AI_ANTI_AIR = "AntiAir";
   public static final String AI_ATTACK_MELEE = "AttackMelee";
   public static final String AI_CHASE_LONG_DISTANCE = "ChaseLongDistance";

--- a/src/main/java/com/codetaylor/mc/onslaught/modules/onslaught/entity/ai/DefaultPriority.java
+++ b/src/main/java/com/codetaylor/mc/onslaught/modules/onslaught/entity/ai/DefaultPriority.java
@@ -4,6 +4,7 @@ package com.codetaylor.mc.onslaught.modules.onslaught.entity.ai;
 public final class DefaultPriority {
 
   // AI Tasks
+  public static final int OFFSCREEN_TELEPORT = -20;
   public static final int LUNGE = -15;
   public static final int CHASE_LONG_DISTANCE = -10;
   public static final int MINING = -9;

--- a/src/main/java/com/codetaylor/mc/onslaught/modules/onslaught/entity/ai/EntityAIOffscreenTeleport.java
+++ b/src/main/java/com/codetaylor/mc/onslaught/modules/onslaught/entity/ai/EntityAIOffscreenTeleport.java
@@ -1,0 +1,110 @@
+package com.codetaylor.mc.onslaught.modules.onslaught.entity.ai;
+
+import static net.minecraftforge.common.MinecraftForge.EVENT_BUS;
+
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.ai.EntityAIBase;
+import net.minecraft.init.SoundEvents;
+import net.minecraftforge.client.event.sound.SoundEvent;
+import net.minecraftforge.event.entity.living.EnderTeleportEvent;
+
+/**
+ * Grants the mob the ability to <a
+ * href=https://tvtropes.org/pmwiki/pmwiki.php/Main/OffscreenTeleportation>Offscreen Teleport</a>
+ * like a horror movie monster.
+ */
+public class EntityAIOffscreenTeleport extends EntityAIBase {
+
+  /** The mob */
+  private final EntityLiving taskOwner;
+  /** the range (sq) that the target must breach to try to teleport */
+  private final int teleportThresholdSq;
+
+  /** the range the mob will teleport to */
+  private final int closeToRange;
+
+  /** may the mob breach not just space but dimension to chase its prey */
+  private final boolean ableToDimHop;
+
+  /** internal counter to stagger the checking to teleport. */
+  private int counter;
+
+  /** total ticks */
+  private static final int TICK_PERIOD = 5;
+
+  private boolean telported = false;
+
+  public EntityAIOffscreenTeleport(
+      EntityLiving taskOwner, int rangeThreshold, int closeToRange, boolean ableToDimHop) {
+    this.taskOwner = taskOwner;
+    this.teleportThresholdSq = rangeThreshold * rangeThreshold;
+    this.closeToRange = closeToRange;
+    this.ableToDimHop = ableToDimHop;
+    this.counter = taskOwner.getRNG().nextInt(TICK_PERIOD);
+  }
+
+  /** Returns whether the EntityAIBase should begin execution. */
+  public boolean shouldExecute() {
+    if (counter++ < TICK_PERIOD) {
+      return false;
+    }
+    counter = 0;
+
+    EntityLivingBase target = taskOwner.getAttackTarget();
+
+    if (target == null) {
+      return false;
+    }
+
+    if (this.ableToDimHop && target.dimension != taskOwner.dimension) {
+      return true;
+    }
+
+    return taskOwner.getDistanceSq(target) >= teleportThresholdSq;
+  }
+
+  /** Execute a one shot task or start executing a continuous task */
+  public void startExecuting() {
+    EntityLivingBase target = taskOwner.getAttackTarget();
+    if (target == null) {
+      System.out.println("no target");
+      return;
+    }
+
+    int offsetX = taskOwner.getRNG().nextBoolean() ? closeToRange : -closeToRange;
+    int offsetZ = taskOwner.getRNG().nextBoolean() ? closeToRange : -closeToRange;
+
+    double teleX = target.posX + offsetX;
+    double teleY = target.posY + 4;
+    double teleZ = target.posZ + offsetZ;
+
+    EnderTeleportEvent event = new EnderTeleportEvent(taskOwner, teleX, teleY, teleZ, 0);
+    boolean wasCanceled = EVENT_BUS.post(event);
+    System.out.println("was canceled:" + wasCanceled);
+    if (wasCanceled) {
+      return;
+    }
+
+    taskOwner.setWorld(target.getEntityWorld());
+    telported = taskOwner.attemptTeleport(teleX, teleY, teleZ);
+    if (telported) {
+      taskOwner.playSound(SoundEvents.ENTITY_ENDERMEN_TELEPORT, 1.0F, .4F);
+      ((EntityLiving)taskOwner).playLivingSound();
+    }
+    System.out.println("was teleported:" + telported);
+  }
+
+  /** Reset the task's internal state. Called when this task is interrupted by another one */
+  public void resetTask() {}
+
+  /** Returns whether an in-progress EntityAIBase should continue executing */
+  public boolean shouldContinueExecuting() {
+    return !telported;
+  }
+
+  /** Keep ticking a continuous task that has already been started */
+  public void updateTask() {
+    startExecuting();
+  }
+}

--- a/src/main/java/com/codetaylor/mc/onslaught/modules/onslaught/entity/ai/injector/EntityAIOffscreenTeleportInjector.java
+++ b/src/main/java/com/codetaylor/mc/onslaught/modules/onslaught/entity/ai/injector/EntityAIOffscreenTeleportInjector.java
@@ -7,6 +7,6 @@ import net.minecraft.nbt.NBTTagCompound;
 public class EntityAIOffscreenTeleportInjector extends EntityAIInjectorBase {
   @Override
   public void inject(EntityLiving entity, NBTTagCompound tag) {
-    entity.tasks.addTask(-20, new EntityAIOffscreenTeleport(entity, 64, 32, true));
+    entity.tasks.addTask(-20, new EntityAIOffscreenTeleport(entity, 64, 1.5f, true));
   }
 }

--- a/src/main/java/com/codetaylor/mc/onslaught/modules/onslaught/entity/ai/injector/EntityAIOffscreenTeleportInjector.java
+++ b/src/main/java/com/codetaylor/mc/onslaught/modules/onslaught/entity/ai/injector/EntityAIOffscreenTeleportInjector.java
@@ -1,0 +1,12 @@
+package com.codetaylor.mc.onslaught.modules.onslaught.entity.ai.injector;
+
+import com.codetaylor.mc.onslaught.modules.onslaught.entity.ai.EntityAIOffscreenTeleport;
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.nbt.NBTTagCompound;
+
+public class EntityAIOffscreenTeleportInjector extends EntityAIInjectorBase {
+  @Override
+  public void inject(EntityLiving entity, NBTTagCompound tag) {
+    entity.tasks.addTask(-20, new EntityAIOffscreenTeleport(entity, 64, 32, true));
+  }
+}

--- a/src/main/java/com/codetaylor/mc/onslaught/modules/onslaught/entity/ai/injector/EntityAIOffscreenTeleportInjector.java
+++ b/src/main/java/com/codetaylor/mc/onslaught/modules/onslaught/entity/ai/injector/EntityAIOffscreenTeleportInjector.java
@@ -1,5 +1,9 @@
 package com.codetaylor.mc.onslaught.modules.onslaught.entity.ai.injector;
 
+import com.codetaylor.mc.onslaught.modules.onslaught.ModuleOnslaughtConfig;
+import com.codetaylor.mc.onslaught.modules.onslaught.ModuleOnslaughtConfig.CustomAI.OffscreenTeleport;
+import com.codetaylor.mc.onslaught.modules.onslaught.Tag;
+import com.codetaylor.mc.onslaught.modules.onslaught.entity.ai.DefaultPriority;
 import com.codetaylor.mc.onslaught.modules.onslaught.entity.ai.EntityAIOffscreenTeleport;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.nbt.NBTTagCompound;
@@ -7,6 +11,21 @@ import net.minecraft.nbt.NBTTagCompound;
 public class EntityAIOffscreenTeleportInjector extends EntityAIInjectorBase {
   @Override
   public void inject(EntityLiving entity, NBTTagCompound tag) {
-    entity.tasks.addTask(-20, new EntityAIOffscreenTeleport(entity, 64, 1.5f, true));
+
+    if (!tag.hasKey(Tag.AI_OFFSCREEN_TELEPORT)) {
+      return;
+    }
+
+    NBTTagCompound aiTag = tag.getCompoundTag(Tag.AI_OFFSCREEN_TELEPORT);
+
+    OffscreenTeleport config = ModuleOnslaughtConfig.CUSTOM_AI.OFFSCREEN_TELEPORT;
+
+    int distance = getInteger(aiTag, Tag.AI_PARAM_TELE_THRESHOLD, config.DEFAULT_RANGE);
+    float factor = (float)getDouble(aiTag, Tag.AI_PARAM_TELE_FACTOR, config.DEFAULT_FACTOR);
+    boolean dimHopping = getBoolean(aiTag, Tag.AI_PARAM_DIM_HOP, config.DEFAULT_DIM_HOPPING);
+
+    entity.tasks.addTask(DefaultPriority.OFFSCREEN_TELEPORT,
+        new EntityAIOffscreenTeleport(
+            entity, distance, factor, dimHopping));
   }
 }

--- a/src/test/java/com/codetaylor/mc/onslaught/modules/onslaught/entity/ai/EntityAIOffscreenTeleportTest.java
+++ b/src/test/java/com/codetaylor/mc/onslaught/modules/onslaught/entity/ai/EntityAIOffscreenTeleportTest.java
@@ -1,11 +1,11 @@
 package com.codetaylor.mc.onslaught.modules.onslaught.entity.ai;
 
 import static com.codetaylor.mc.onslaught.modules.onslaught.entity.ai.EntityAIOffscreenTeleport.towards;
-import static net.minecraftforge.common.MinecraftForge.EVENT_BUS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyDouble;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -14,7 +14,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.Random;
 import net.minecraft.entity.EntityLiving;
-import net.minecraftforge.fml.common.eventhandler.EventBus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -24,7 +23,7 @@ class EntityAIOffscreenTeleportTest {
 
   @BeforeEach
   void createMobAndTarget() {
-    EntityAIOffscreenTeleport.setChanceOutOfTicks(1);
+    EntityAIOffscreenTeleport.setRunChanceOutcomes(1);
 
     mob = mock(EntityLiving.class, CALLS_REAL_METHODS);
     target = mock(EntityLiving.class, CALLS_REAL_METHODS);
@@ -59,9 +58,10 @@ class EntityAIOffscreenTeleportTest {
     target.posY = 20;
     target.posZ = -50;
 
-    EntityAIOffscreenTeleport task = new EntityAIOffscreenTeleport(mob, 100, 0.5f, false);
-
+    EntityAIOffscreenTeleport task = spy(new EntityAIOffscreenTeleport(mob, 100, 0.5f, false));
     doReturn(true).when(mob).attemptTeleport(anyDouble(), anyDouble(), anyDouble());
+    doReturn(null).when(task).invisibilityEffect();
+    doNothing().when(mob).addPotionEffect(any());
 
     task.startExecuting();
 

--- a/src/test/java/com/codetaylor/mc/onslaught/modules/onslaught/entity/ai/EntityAIOffscreenTeleportTest.java
+++ b/src/test/java/com/codetaylor/mc/onslaught/modules/onslaught/entity/ai/EntityAIOffscreenTeleportTest.java
@@ -1,0 +1,84 @@
+package com.codetaylor.mc.onslaught.modules.onslaught.entity.ai;
+
+import static com.codetaylor.mc.onslaught.modules.onslaught.entity.ai.EntityAIOffscreenTeleport.towards;
+import static net.minecraftforge.common.MinecraftForge.EVENT_BUS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyDouble;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Random;
+import net.minecraft.entity.EntityLiving;
+import net.minecraftforge.fml.common.eventhandler.EventBus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class EntityAIOffscreenTeleportTest {
+  EntityLiving mob;
+  EntityLiving target;
+
+  @BeforeEach
+  void createMobAndTarget() {
+    EntityAIOffscreenTeleport.setChanceOutOfTicks(1);
+
+    mob = mock(EntityLiving.class, CALLS_REAL_METHODS);
+    target = mock(EntityLiving.class, CALLS_REAL_METHODS);
+
+    when(mob.getAttackTarget()).thenReturn(target);
+    when(mob.getRNG()).thenReturn(new Random());
+  }
+
+  @Test
+  void test_shouldExecute_close() {
+    target.posX = 99;
+    EntityAIOffscreenTeleport task = new EntityAIOffscreenTeleport(mob, 100, 0, false);
+
+    assertThat(task.shouldExecute()).isFalse();
+  }
+
+  @Test
+  void test_shouldExecute_far() {
+    target.posX = 101;
+    EntityAIOffscreenTeleport task = new EntityAIOffscreenTeleport(mob, 100, 0, false);
+
+    assertThat(task.shouldExecute()).isTrue();
+  }
+
+  @Test
+  void test_startExecuting() {
+    mob.posX = 10;
+    mob.posY = 10;
+    mob.posZ = 10;
+
+    target.posX = 100;
+    target.posY = 20;
+    target.posZ = -50;
+
+    EntityAIOffscreenTeleport task = new EntityAIOffscreenTeleport(mob, 100, 0.5f, false);
+
+    doReturn(true).when(mob).attemptTeleport(anyDouble(), anyDouble(), anyDouble());
+
+    task.startExecuting();
+
+    verify(mob).attemptTeleport(55d, 15d, -20d);
+  }
+
+  @Test
+  void towards_at_a_50_factor() {
+    assertThat(towards(0, 100, 0.5f)).isEqualTo(50);
+    assertThat(towards(-50, 100, 0.5f)).isEqualTo(25);
+    assertThat(towards(100, 50, 0.5f)).isEqualTo(75);
+  }
+
+  @Test
+  void towards_at_a_150_factor() {
+    assertThat(towards(0, 100, 1.5f)).isEqualTo(150);
+    assertThat(towards(-50, 100, 1.5f)).isEqualTo(175);
+    assertThat(towards(100, 50, 1.5f)).isEqualTo(25);
+  }
+}

--- a/src/test/resources/config/templates/invasion/teleporter_invasions.json
+++ b/src/test/resources/config/templates/invasion/teleporter_invasions.json
@@ -1,0 +1,62 @@
+{
+  "teleport.defaults": {
+    "name": "Default Teleports",
+    "selector": {
+      "weight": 1,
+      "dimension": {
+        "type": "include",
+        "dimensions": [
+          0
+        ]
+      }
+    },
+    "waves": [
+      {
+        "groups": [
+          {
+            "weight": 1,
+            "forceSpawn": true,
+            "mobs": [
+              {
+                "id": "teleporter.default",
+                "count": [
+                  5
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "teleport.flankers": {
+    "name": "Flanking Teleports",
+    "selector": {
+      "weight": 1,
+      "dimension": {
+        "type": "include",
+        "dimensions": [
+          0
+        ]
+      }
+    },
+    "waves": [
+      {
+        "groups": [
+          {
+            "weight": 1,
+            "forceSpawn": true,
+            "mobs": [
+              {
+                "id": "teleporter.flanker",
+                "count": [
+                  5
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/test/resources/config/templates/mob/teleporters.json
+++ b/src/test/resources/config/templates/mob/teleporters.json
@@ -1,0 +1,31 @@
+{
+  "teleporter.default": {
+    "id": "minecraft:husk",
+    "nbt": {
+      "ForgeData": {
+        "Onslaught": {
+          "CustomAI": {
+            "OffscreenTeleport": {}
+          }
+        }
+      }
+    }
+  },
+  "teleporter.flanker": {
+    "id": "minecraft:husk",
+    "nbt": {
+      "CustomName": "Flanking Husk",
+      "ForgeData": {
+        "Onslaught": {
+          "CustomAI": {
+            "OffscreenTeleport": {
+              "TeleportDistance": 32,
+              "TeleportFactor": 1.3,
+              "DimensionHopping": true
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Resolves: #15 with a new AI task that gives the invasion mobs the power to teleport a fraction of the distance closer.

❗ Due to core minecraft mechanics, any task cannot prevent the entity from going inactive or unloading.

### Add

1. `EntityAIOffscreenTeleport`, a task that translocates a mob that finds itself outside a certain range of the target.
    * includes all config, nbt management trimmings
2. docs on usage

### Validation

1. unit tests for mathematics of teleport
2.  wrote test invasions for `Chaser` and `Flanker` patterns
1. `runClient` and test using the invasions