### PR TITLE
fix airspawn, fix mod config loading. Add some test fliers.

### DIFF
--- a/docs/invasion/template.md
+++ b/docs/invasion/template.md
@@ -1,9 +1,10 @@
 # Invasion Template
 
-Invasion templates are `.json` files located in `config/onslaught/templates/invasion`. Sub-folders are not detected and all template files must be placed in the root of this folder.
+Invasion templates are `.json` files located in `config/onslaught/templates/invasion`. Sub-folders
+are not detected and all template files must be placed in the root of this folder.
 
-Each file can contain as many invasion definitions as you like so long as the id of each definition is unique across all files.
-
+Each file can contain as many invasion definitions as you like so long as the id of each definition
+is unique across all files.
 
 ## Definitions
 
@@ -17,27 +18,30 @@ waves    | Waves[]  | defines the waves spawned by the invasion
 
 ```json
 {
-    "unique_invasion_id": {
-        "name": "Invasion Name",
-        "selector": {
-            ...
-        },
-        "messages": {
-            ...
-        },
-        "commands": {
-            ...
-        },
-        "waves": [
-            ...
-        ]
-    }
+  "unique_invasion_id": {
+    "name": "Invasion Name",
+    "selector": {
+      ...
+    },
+    "messages": {
+      ...
+    },
+    "commands": {
+      ...
+    },
+    "waves": [
+      ...
+    ]
+  }
 }
 ```
 
-The `unique_invasion_id` key denotes a unique name for the invasion definition and can be anything you like so long as it is unique across all invasion template files. This name is used to reference the invasion definition in Onslaught's `ostart` command. 
+The `unique_invasion_id` key denotes a unique name for the invasion definition and can be anything
+you like so long as it is unique across all invasion template files. This name is used to reference
+the invasion definition in Onslaught's `ostart` command.
 
-The `name` key is optional and if omitted, defaults to `""` which will prevent the name from being displayed on the progress bar.
+The `name` key is optional and if omitted, defaults to `""` which will prevent the name from being
+displayed on the progress bar.
 
 ## Selector
 
@@ -51,17 +55,17 @@ weight     | int | defines the invasion selector's weight
 
 ```json
 {
-    "unique_invasion_id": {
-        "selector": {
-            "dimension": {
-                ...
-            },
-            "gamestages": {
-                ...
-            },
-            "weight": 100
-        }
+  "unique_invasion_id": {
+    "selector": {
+      "dimension": {
+        ...
+      },
+      "gamestages": {
+        ...
+      },
+      "weight": 100
     }
+  }
 }
 ```
 
@@ -76,38 +80,49 @@ dimensions      | int[]   | N/A | the dimension id list
 
 ```json
 {
-    "unique_invasion_id": {
-        "selector": {
-            "dimension": {
-                "type": "include",
-                "dimensions": [0]
-            }
-        }
+  "unique_invasion_id": {
+    "selector": {
+      "dimension": {
+        "type": "include",
+        "dimensions": [
+          0
+        ]
+      }
     }
+  }
 }
 ```
 
 ### GameStages
 
-The `gamestages` object is defined using nested sets of `Stages` objects. GameStages is an external optional mod, linked [here](https://www.curseforge.com/minecraft/mc-mods/game-stages).
+The `gamestages` object is defined using nested sets of `Stages` objects. GameStages is an external
+optional mod, linked [here](https://www.curseforge.com/minecraft/mc-mods/game-stages).
 
-`Stages` objects use the keys `and`, `or`, and `not` to define their type. Stage names do not need to follow any name classification - the names below are purely for example.
+`Stages` objects use the keys `and`, `or`, and `not` to define their type. Stage names do not need
+to follow any name classification - the names below are purely for example.
 
 Each `Stages` object can have only one key.
 
 ```json
 {
-    "unique_invasion_id": {
-        "selector": {
-            "gamestages": {
-                "and": [
-                    "stage0",
-                    {"or": ["stage1", "stage2"]},
-                    {"not": "stage3"}
-                ]
-            }
-        }
+  "unique_invasion_id": {
+    "selector": {
+      "gamestages": {
+        "and": [
+          "stage0",
+          {
+            "or": [
+              "stage1",
+              "stage2"
+            ]
+          },
+          {
+            "not": "stage3"
+          }
+        ]
+      }
     }
+  }
 }
 ```
 
@@ -119,7 +134,8 @@ This example will match a player that:
 
 #### and
 
-The `Stages` object `and` consists of an array of elements that are either a `string` or `Stages` object.
+The `Stages` object `and` consists of an array of elements that are either a `string` or `Stages`
+object.
 
 `and` requires all of the elements to evaluate to true in order to evaluate to true.
 
@@ -132,7 +148,8 @@ In this example, the player must have both `stage0` *and* `stage1`.
 
 #### or
 
-The `Stages` object `or` consists of an array of elements that are either a `string` or `Stages` object.
+The `Stages` object `or` consists of an array of elements that are either a `string` or `Stages`
+object.
 
 `or` requires at least one of the elements to evaluate to true in order to evaluate to true.
 
@@ -145,7 +162,8 @@ In this example, the player must have either `stage0` *or* `stage1`.
 
 #### not
 
-The `Stages` object `not` is different from the others in that it does not use an array. It consists of either a single `string` or `Stages` object.
+The `Stages` object `not` is different from the others in that it does not use an array. It consists
+of either a single `string` or `Stages` object.
 
 `not` requires its value to evaluate to false in order to evaluate to true.
 
@@ -162,16 +180,21 @@ In this example, the player must not have `stage0`.
 
 ```json
 {
-    "unique_invasion_id": {
-        "selector": {
-            "gamestages": {
-                "and": [
-                    "stage0",
-                    {"or": ["stage1", "stage2"]}
-                ]
-            }
-        }
+  "unique_invasion_id": {
+    "selector": {
+      "gamestages": {
+        "and": [
+          "stage0",
+          {
+            "or": [
+              "stage1",
+              "stage2"
+            ]
+          }
+        ]
+      }
     }
+  }
 }
 ```
 
@@ -184,16 +207,21 @@ This example will match a player that:
 
 ```json
 {
-    "unique_invasion_id": {
-        "selector": {
-            "gamestages": {
-                "or": [
-                    "stage0",
-                    {"and": ["stage1", "stage2"]}
-                ]
-            }
-        }
+  "unique_invasion_id": {
+    "selector": {
+      "gamestages": {
+        "or": [
+          "stage0",
+          {
+            "and": [
+              "stage1",
+              "stage2"
+            ]
+          }
+        ]
+      }
     }
+  }
 }
 ```
 
@@ -206,13 +234,13 @@ This example will match a player that:
 
 ```json
 {
-    "unique_invasion_id": {
-        "selector": {
-            "gamestages": {
-                "not": "stage0"
-            }
-        }
+  "unique_invasion_id": {
+    "selector": {
+      "gamestages": {
+        "not": "stage0"
+      }
     }
+  }
 }
 ```
 
@@ -224,17 +252,36 @@ This example will match a player that:
 
 ```json
 {
-    "unique_invasion_id": {
-        "selector": {
-            "gamestages": {
-                "and": [
-                    "stage0",
-                    {"or": ["stage1", {"not": "stage2"}]},
-                    {"and": ["stage3", {"or": ["stage4", "not": "stage5"]}]}
+  "unique_invasion_id": {
+    "selector": {
+      "gamestages": {
+        "and": [
+          "stage0",
+          {
+            "or": [
+              "stage1",
+              {
+                "not": "stage2"
+              }
+            ]
+          },
+          {
+            "and": [
+              "stage3",
+              {
+                "or": [
+                  "stage4",
+                  "not"
+                  :
+                  "stage5"
                 ]
-            }
-        }
+              }
+            ]
+          }
+        ]
+      }
     }
+  }
 }
 ```
 
@@ -249,15 +296,19 @@ This example will match a player that:
 
 ```json
 {
-    "unique_invasion_id": {
-        "selector": {
-            "gamestages": {
-                "not": {
-                    "or": ["stage0", "stage1", "stage2"]
-                }
-            }
+  "unique_invasion_id": {
+    "selector": {
+      "gamestages": {
+        "not": {
+          "or": [
+            "stage0",
+            "stage1",
+            "stage2"
+          ]
         }
+      }
     }
+  }
 }
 ```
 
@@ -265,22 +316,26 @@ This example will match a player that:
 
 * does not have *any* of the given stages
 
-!!! note
-    In this example the player must have at least one of the given stages to fail the evaluation.
+!!! note In this example the player must have at least one of the given stages to fail the
+    evaluation.
 
 **Example F:**
 
 ```json
 {
-    "unique_invasion_id": {
-        "selector": {
-            "gamestages": {
-                "not": {
-                    "and": ["stage0", "stage1", "stage2"]
-                }
-            }
+  "unique_invasion_id": {
+    "selector": {
+      "gamestages": {
+        "not": {
+          "and": [
+            "stage0",
+            "stage1",
+            "stage2"
+          ]
         }
+      }
     }
+  }
 }
 ```
 
@@ -288,20 +343,23 @@ This example will match a player that:
 
 * does not have *all* of the given stages
 
-!!! note
-    In this example the player must have all of the given stages to fail the evaluation. If they have just one or two of the stages, the selector will evaluate to true.
+!!! note In this example the player must have all of the given stages to fail the evaluation. If
+    they have just one or two of the stages, the selector will evaluate to true.
 
 ### Weight
 
-If an invasion's `dimension` and `gamestages` selectors allow the invasion to be selected, it is placed into a collection with all the other allowed invasions. One invasion is randomly selected from the collection and invasions with a larger weight will be selected more often, relative to the total weight of all invasions in the collection.
+If an invasion's `dimension` and `gamestages` selectors allow the invasion to be selected, it is
+placed into a collection with all the other allowed invasions. One invasion is randomly selected
+from the collection and invasions with a larger weight will be selected more often, relative to the
+total weight of all invasions in the collection.
 
 ```json
 {
-    "unique_invasion_id": {
-        "selector": {
-            "weight": 100
-        }
+  "unique_invasion_id": {
+    "selector": {
+      "weight": 100
     }
+  }
 }
 ```
 
@@ -317,16 +375,16 @@ warn  | Warning | defines the early warning message sent to a player before thei
 
 ```json
 {
-    "unique_invasion_id": {
-        "messages": {
-            "start": "Zombies appear!",
-            "end": "The threat has been neutralized!",
-            "warn": {
-                "message": "You can smell Zombies!",
-                "ticks": 12000
-            }
-        }
+  "unique_invasion_id": {
+    "messages": {
+      "start": "Zombies appear!",
+      "end": "The threat has been neutralized!",
+      "warn": {
+        "message": "You can smell Zombies!",
+        "ticks": 12000
+      }
     }
+  }
 }
 ```
 
@@ -334,8 +392,8 @@ warn  | Warning | defines the early warning message sent to a player before thei
 
 An early warning message can be sent to a player long before their invasion starts.
 
-!!! note
-    Due to the way the invasion system works, early warning messages can only be sent up to 12000 ticks, or 10 minutes, early.
+!!! note Due to the way the invasion system works, early warning messages can only be sent up to
+    12000 ticks, or 10 minutes, early.
 
 key | type | range | description
 :---|:---|:---|:---
@@ -346,10 +404,12 @@ ticks      | int   | [0, 12000] | how many ticks before the invasion starts shou
 
 ## Commands
 
-Commands can be executed at the start and end of an invasion as well as at different stages of an invasion's completion.
+Commands can be executed at the start and end of an invasion as well as at different stages of an
+invasion's completion.
 
-!!! note
-    All commands are executed as if they were executed by the invaded player with an elevated permission level. This allows the usage of things like `@p` to reference the player and relative coordinates like `~ ~10 ~`.
+!!! note All commands are executed as if they were executed by the invaded player with an elevated
+    permission level. This allows the usage of things like `@p` to reference the player and relative
+    coordinates like `~ ~10 ~`.
 
 key | type | description
 :---|:---|:---
@@ -359,31 +419,34 @@ staged  | StagedCommand[] | defines an array of `StagedCommand` definitions
 
 ```json
 {
-    "unique_invasion_id": {
-        "commands": {
-            "start": [
-                "/say My invasion is starting!"
-            ],
-            "end": [
-                "/say My invasion has ended!"
-            ],
-            "staged": [
-                ...
-            ]
-        }
+  "unique_invasion_id": {
+    "commands": {
+      "start": [
+        "/say My invasion is starting!"
+      ],
+      "end": [
+        "/say My invasion has ended!"
+      ],
+      "staged": [
+        ...
+      ]
     }
+  }
 }
 ```
 
 #### StagedCommand
 
-Staged commands will be executed once after an invasion's completion percentage exceeds the staged command's given `complete` value.
+Staged commands will be executed once after an invasion's completion percentage exceeds the staged
+command's given `complete` value.
 
-!!! note
-    Due to the way that the invasion completion percentage is evaluated and the command executor is triggered, commands with a `complete` value of `0` will not be executed until an invasion mob dies. To run commands at the beginning of an invasion, use the `start` definition instead.
+!!! note Due to the way that the invasion completion percentage is evaluated and the command
+    executor is triggered, commands with a `complete` value of `0` will not be executed until an
+    invasion mob dies. To run commands at the beginning of an invasion, use the `start` definition
+    instead.
 
-!!! warning
-    You can define up to a maximum of 64 different `StagedCommand` definitions in the `invasion/commands/staged` array.
+!!! warning You can define up to a maximum of 64 different `StagedCommand` definitions in
+    the `invasion/commands/staged` array.
 
 key | type | range | description
 :---|:---|:---|:---
@@ -392,10 +455,10 @@ commands    | string[]   | N/A | defines an array of commands to be executed
 
 ```json
 {
-    "complete": 0.25,
-    "commands": [
-        "/say My invasion is 25% complete!"
-    ]
+  "complete": 0.25,
+  "commands": [
+    "/say My invasion is 25% complete!"
+  ]
 }
 ```
 
@@ -403,47 +466,57 @@ commands    | string[]   | N/A | defines an array of commands to be executed
 
 Waves define the mobs that will be spawned in the invasion.
 
-Each wave listed in the `waves` definition will be spawned sequentially and each wave can be delayed from the start of the invasion.
+Each wave listed in the `waves` definition will be spawned sequentially and each wave can be delayed
+from the start of the invasion.
 
 ```json
 {
-    "unique_invasion_id": {
-        "waves": [
-            ...
-        ]
-    }
+  "unique_invasion_id": {
+    "waves": [
+      ...
+    ]
+  }
 }
 ```
 
 #### Wave
 
-The `Wave` object defines the mobs that will spawn in the wave and how the spawner will try to spawn them.
+The `Wave` object defines the mobs that will spawn in the wave and how the spawner will try to spawn
+them.
 
-Each wave can be delayed from the start of the invasion. If the player hasn't defeated all previous waves by the time that the wave's delay expires, the wave will be spawned. The wave will also be spawned immediately after a player defeats all previous waves.
+Each wave can be delayed from the start of the invasion. If the player hasn't defeated all previous
+waves by the time that the wave's delay expires, the wave will be spawned. The wave will also be
+spawned immediately after a player defeats all previous waves.
 
 key | type | optional | default| description
 :---|:---|:---|:---|:---
-delayTicks   | int[min, max] *or* int[fixed] | yes | `[0]` | defines how long to wait to spawn this wave after the invasions starts
+delayTicks   | int[min, max] *
+or* int[fixed] | yes | `[0]` | defines how long to wait to spawn this wave after the invasions starts
 groups       | Group[]       | no  | - | defines an array of groups, one will be selected
 secondaryMob | SecondaryMob  | yes | config | defines a secondary mob to spawn when the primary mob spawn fails
 
 ```json
 {
-    "delayTicks": [3600, 4000],
-    "groups": [
-        ...
-    ],
-    "secondaryMob": {
-        ...
-    }
+  "delayTicks": [
+    3600,
+    4000
+  ],
+  "groups": [
+    ...
+  ],
+  "secondaryMob": {
+    ...
+  }
 }
 ```
 
 #### Group
 
-One group is randomly selected from the collection and groups with a larger weight will be selected more often, relative to the total weight of all groups in the collection.
+One group is randomly selected from the collection and groups with a larger weight will be selected
+more often, relative to the total weight of all groups in the collection.
 
-Enabling `forceSpawn` will try to spawn the mob using the delayed spawn system if the primary spawn type fails. The delayed spawn system will ignore the light level when attempting spawns.
+Enabling `forceSpawn` will try to spawn the mob using the delayed spawn system if the primary spawn
+type fails. The delayed spawn system will ignore the light level when attempting spawns.
 
 key | type | optional | default| description
 :---|:---|:---|:---|:---
@@ -453,11 +526,11 @@ mobs       | Mob[]   | no | - | all mobs defined here will be spawned for the wa
 
 ```json
 {
-    "weight": 100,
-    "forceSpawn": true,
-    "mobs": [
-        ...
-    ]
+  "weight": 100,
+  "forceSpawn": true,
+  "mobs": [
+    ...
+  ]
 }
 ```
 
@@ -473,11 +546,14 @@ spawn | SpawnType                   | yes | config | defines how to try and spaw
 
 ```json
 {
-    "id": "invasion_zombie",
-    "count": [8, 16],
-    "spawn": {
-        ...
-    }
+  "id": "invasion_zombie",
+  "count": [
+    8,
+    16
+  ],
+  "spawn": {
+    ...
+  }
 }
 ```
 
@@ -495,13 +571,21 @@ stepRadius     | int         | yes | config | defines the step radius for the sp
 sampleDistance | int         | yes | config | defines the sample distance for the spawn sampler
 
 ```json
-"spawn": {
+{
+  "spawn": {
     "type": "ground",
-    "light": [0, 7],
-    "rangeXZ": [16, 32],
+    "light": [
+      0,
+      7
+    ],
+    "rangeXZ": [
+      16,
+      32
+    ],
     "rangeY": 16,
     "stepRadius": 4,
     "sampleDistance": 2
+  }
 }
 ```
 
@@ -515,10 +599,12 @@ id    | int                         | yes | config | defines the mob template id
 spawn | SpawnType                   | yes | config | defines how to try and spawn the mob
 
 ```json
-"secondaryMob": {
+{
+  "secondaryMob": {
     "id": "invasion_vex",
     "spawn": {
-        ...
+      ...
     }
+  }
 }
 ```

--- a/src/main/java/com/codetaylor/mc/onslaught/modules/onslaught/ModuleOnslaughtConfig.java
+++ b/src/main/java/com/codetaylor/mc/onslaught/modules/onslaught/ModuleOnslaughtConfig.java
@@ -1,9 +1,11 @@
 package com.codetaylor.mc.onslaught.modules.onslaught;
 
+import static com.codetaylor.mc.onslaught.modules.onslaught.ModuleOnslaught.MOD_ID;
+
 import com.codetaylor.mc.onslaught.modules.onslaught.template.invasion.InvasionTemplateWave;
 import net.minecraftforge.common.config.Config;
 
-@Config(modid = ModuleOnslaught.MOD_ID)
+@Config(modid = MOD_ID, name = MOD_ID + '/' + MOD_ID)
 public class ModuleOnslaughtConfig {
 
   public static Debug DEBUG = new Debug();
@@ -203,6 +205,7 @@ public class ModuleOnslaughtConfig {
     public AttackMelee ATTACK_MELEE = new AttackMelee();
     public LongDistanceChase LONG_DISTANCE_CHASE = new LongDistanceChase();
     public Mining MINING = new Mining();
+
     @Config.Name("Offscreen Teleport")
     public OffscreenTeleport OFFSCREEN_TELEPORT = new OffscreenTeleport();
 

--- a/src/main/java/com/codetaylor/mc/onslaught/modules/onslaught/invasion/sampler/predicate/SpawnPredicateAir.java
+++ b/src/main/java/com/codetaylor/mc/onslaught/modules/onslaught/invasion/sampler/predicate/SpawnPredicateAir.java
@@ -27,7 +27,7 @@ public class SpawnPredicateAir implements Predicate<EntityLiving> {
     double verticalMin = Math.max(0, -this.verticalRange + entity.posY);
     double verticalMax = Math.min(255, this.verticalRange + entity.posY);
 
-    for (double y = verticalMin; y <= verticalMax; y++) {
+    for (double y = verticalMax; y >= verticalMin; y--) {
       entity.setPosition(entity.posX, y, entity.posZ);
 
       if (this.testEntityPosition(entity)) {

--- a/src/test/resources/config/templates/invasion/flier_invasion.json
+++ b/src/test/resources/config/templates/invasion/flier_invasion.json
@@ -1,0 +1,145 @@
+{
+  "fliers.freefall": {
+    "name": "Husktigee Airmen",
+    "selector": {
+      "weight": 1,
+      "dimension": {
+        "type": "include",
+        "dimensions": [
+          0
+        ]
+      }
+    },
+    "waves": [
+      {
+        "delayTicks": [
+          100
+        ],
+        "groups": [
+          {
+            "weight": 1,
+            "forceSpawn": true,
+            "mobs": [
+              {
+                "id": "husky_airman",
+                "count": [
+                  5
+                ],
+                "spawn": {
+                  "type": "air",
+                  "light": [
+                    0,
+                    14
+                  ],
+                  "rangeXZ": [
+                    4,
+                    16
+                  ],
+                  "rangeY": 16,
+                  "stepRadius": 4,
+                  "sampleDistance": 2
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "delayTicks": [
+          100
+        ],
+        "groups": [
+          {
+            "weight": 1,
+            "forceSpawn": true,
+            "mobs": [
+              {
+                "id": "husky_airman",
+                "count": [
+                  5
+                ],
+                "spawn": {
+                  "type": "air",
+                  "light": [
+                    0,
+                    14
+                  ],
+                  "rangeXZ": [
+                    4,
+                    16
+                  ],
+                  "rangeY": 16,
+                  "stepRadius": 4,
+                  "sampleDistance": 2
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "delayTicks": [
+          100
+        ],
+        "groups": [
+          {
+            "weight": 1,
+            "forceSpawn": true,
+            "mobs": [
+              {
+                "id": "husky_airman",
+                "count": [
+                  5
+                ],
+                "spawn": {
+                  "type": "air",
+                  "light": [
+                    0,
+                    14
+                  ],
+                  "rangeXZ": [
+                    4,
+                    16
+                  ],
+                  "rangeY": 16,
+                  "stepRadius": 4,
+                  "sampleDistance": 2
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "fliers.blaze": {
+    "name": "A Blazing Invasion",
+    "selector": {
+      "weight": 1,
+      "dimension": {
+        "type": "include",
+        "dimensions": [
+          0
+        ]
+      }
+    },
+    "waves": [
+      {
+        "groups": [
+          {
+            "weight": 1,
+            "forceSpawn": true,
+            "mobs": [
+              {
+                "id": "blaze",
+                "count": [
+                  5
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/test/resources/config/templates/mob/fliers.json
+++ b/src/test/resources/config/templates/mob/fliers.json
@@ -1,0 +1,16 @@
+{
+  "husky_airman": {
+    "id": "minecraft:husk",
+    "effects": [
+      {
+        "id": "minecraft:glowing",
+        "duration": 9999,
+        "amplifier": 0,
+        "showParticles": true
+      }
+    ]
+  },
+  "blaze": {
+    "id": "minecraft:blaze"
+  }
+}


### PR DESCRIPTION
Solves #13 by ensuring airtypes spawn at the highest allowed elevation

### Add

1. Test fliers

### Change

1. AirSpawn type now attempts to spawn top to bottom in Y range, rather than bottom to top

### Fix

1. revert mod config file name (so the config is in the onslaught sub folder).

### Validation

1. A demonstration Duh da da da duh

https://user-images.githubusercontent.com/5504626/113516719-ca0e0600-9549-11eb-9f4f-0b1d9c1418aa.mp4