### PR TITLE
Add beneath spawn type, ground spawns top to bottom

### DIFF
--- a/docs/invasion/template.md
+++ b/docs/invasion/template.md
@@ -563,12 +563,18 @@ This defines how the spawner will try to spawn a mob.
 
 key | type | optional | default| description
 :---|:---|:---|:---|:---
-type    | string             | yes | config | defines the spawn type, value values are `ground` and `air`
+type    | string             | yes | config | defines the spawn type, value values are `ground`, `air`, and `beneath`
 light   | int[min, max]      | yes | config | defines the light range to spawn the mob in
 rangeXZ | int[min, max]      | yes | config | defines how far away from the player to try and spawn the mob
 rangeY  | int                | yes | config | defines how far +/- Y to try and spawn the mob
 stepRadius     | int         | yes | config | defines the step radius for the spawn sampler
 sampleDistance | int         | yes | config | defines the sample distance for the spawn sampler
+
+Spawn Type | Description
+---------- | -----------
+ground     | Spawns on solid ground, preferring higher elevations
+air        | Spawns in air, preferring the air
+beneath    | Spawns on solid ground, preferring lower elevations
 
 ```json
 {

--- a/src/main/java/com/codetaylor/mc/onslaught/modules/onslaught/invasion/sampler/predicate/SpawnPredicateBeneath.java
+++ b/src/main/java/com/codetaylor/mc/onslaught/modules/onslaught/invasion/sampler/predicate/SpawnPredicateBeneath.java
@@ -6,14 +6,14 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 
 /** Responsible for testing a pillar of blocks for a valid ground spawn location. */
-public class SpawnPredicateGround implements Predicate<EntityLiving> {
+public class SpawnPredicateBeneath implements Predicate<EntityLiving> {
 
   private final BlockPos.MutableBlockPos blockPos;
   private final int lightMin;
   private final int lightMax;
   private final int verticalRange;
 
-  public SpawnPredicateGround(int lightMin, int lightMax, int verticalRange) {
+  public SpawnPredicateBeneath(int lightMin, int lightMax, int verticalRange) {
 
     super();
     this.blockPos = new BlockPos.MutableBlockPos();
@@ -28,7 +28,7 @@ public class SpawnPredicateGround implements Predicate<EntityLiving> {
     double verticalMin = Math.max(0, -this.verticalRange + entity.posY);
     double verticalMax = Math.min(255, this.verticalRange + entity.posY);
 
-    for (double y = verticalMax; y >= verticalMin; y--) {
+    for (double y = verticalMin; y <= verticalMax; y++) {
       entity.setPosition(entity.posX, y, entity.posZ);
 
       if (this.testEntityPosition(entity)) {

--- a/src/main/java/com/codetaylor/mc/onslaught/modules/onslaught/invasion/sampler/predicate/SpawnPredicateFactory.java
+++ b/src/main/java/com/codetaylor/mc/onslaught/modules/onslaught/invasion/sampler/predicate/SpawnPredicateFactory.java
@@ -26,6 +26,12 @@ public class SpawnPredicateFactory {
           return new SpawnPredicateAir(light[0], light[1], spawnData.rangeY);
         }
 
+      case beneath:
+      {
+        int[] light = Util.evaluateRangeArray(spawnData.light);
+        return new SpawnPredicateBeneath(light[0], light[1], spawnData.rangeY);
+      }
+
       default:
         throw new IllegalArgumentException("Unknown spawn type: " + spawnData.type);
     }

--- a/src/main/java/com/codetaylor/mc/onslaught/modules/onslaught/template/invasion/InvasionTemplateWave.java
+++ b/src/main/java/com/codetaylor/mc/onslaught/modules/onslaught/template/invasion/InvasionTemplateWave.java
@@ -25,7 +25,8 @@ public class InvasionTemplateWave {
      */
 
     ground,
-    air
+    air,
+    beneath
   }
 
   public static class Group {

--- a/src/test/resources/config/templates/invasion/flier_invasion.json
+++ b/src/test/resources/config/templates/invasion/flier_invasion.json
@@ -29,7 +29,7 @@
                   "type": "air",
                   "light": [
                     0,
-                    14
+                    15
                   ],
                   "rangeXZ": [
                     4,


### PR DESCRIPTION
Change ground spawn to spawn highest elevation to lowest. This should encourage 'surface' mobs that will spawn in light to not be placed underground if the player is on the surface.

### Add

1. Beneath spawn type. Beneath is effectively like old ground spawn

### Change

1. ground spawn type now attempts to spawn from highest elevation, to lowest.

### Fix

### Validation

1. Run `clean` and `runClient`, `runServer`.
1. Tested same horde (husks, any light) with the 3 different spawn types.