### PR TITLE
Fixed wrong access transformer

### DIFF
--- a/src/main/resources/META-INF/onslaught_at.cfg
+++ b/src/main/resources/META-INF/onslaught_at.cfg
@@ -1,1 +1,1 @@
-public net.minecraft.entity.ai.EntityAITasks field_75780_b # executingTaskEntries
+public-f net.minecraft.entity.ai.EntityAITasks field_75780_b # executingTaskEntries


### PR DESCRIPTION
The access transformer needs to remove final from the field so there wont be any crashes.
Also your manifest.mf generated does not have the fmlat field which loads the access transformer causing crashes.